### PR TITLE
DEN-98 Enable batch and regex string replace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Vim backup files
+*.swp

--- a/objectpath/core/interpreter.py
+++ b/objectpath/core/interpreter.py
@@ -656,6 +656,14 @@ class Tree(Debugger):
         elif fnName == "replace":
           if sys.version_info[0] < 3 and type(args[0]) is unicode:
             args[0] = args[0].encode("utf8")
+          if len(args) == 2 and type(args[1]) is dict:
+            replaced = args[0]
+            for k, v in args[1].items():
+                if type(k) == re.Pattern:
+                    replaced = re.sub(k, v, replaced)
+                else:
+                    replaced = str.replace(replaced, k, v)
+            return replaced
           if type(args[1]) == re.Pattern:
             return re.sub(args[1], args[2], args[0])
           return str.replace(args[0], args[1], args[2])

--- a/objectpath/core/interpreter.py
+++ b/objectpath/core/interpreter.py
@@ -656,6 +656,8 @@ class Tree(Debugger):
         elif fnName == "replace":
           if sys.version_info[0] < 3 and type(args[0]) is unicode:
             args[0] = args[0].encode("utf8")
+          if type(args[1]) == re.Pattern:
+            return re.sub(args[1], args[2], args[0])
           return str.replace(args[0], args[1], args[2])
         # TODO this should be supported by /regex/
         # elif fnName=="REsub":

--- a/objectpath/core/parser.py
+++ b/objectpath/core/parser.py
@@ -252,7 +252,7 @@ def nud(self):  # pylint: disable=E0102
       else:
         self_fst_append(token.id)
       advance()
-  self.fst = "".join(regex).replace("\\", "\\\\")
+  self.fst = "".join(regex)#.replace("\\", "\\\\")
   advance("/")
   return self
 

--- a/tests/test_ObjectPath.py
+++ b/tests/test_ObjectPath.py
@@ -401,6 +401,7 @@ class ObjectPath(unittest.TestCase):
 
   def test_builtin_string(self):
     self.assertEqual(execute("replace('foobar','oob','baz')"), 'fbazar')
+    self.assertEqual(execute("replace('foobar', /[obr]/, '.')"), 'f...a.')
     self.assertEqual(execute("""escape('&lt;')"""), "&amp;lt;")
     self.assertEqual(execute("""escape('<"&>')"""), "&lt;&quot;&amp;&gt;")
     self.assertEqual(execute("""unescape('&lt;&quot;&amp;&gt;')"""), "<\"&>")

--- a/tests/test_ObjectPath.py
+++ b/tests/test_ObjectPath.py
@@ -402,6 +402,7 @@ class ObjectPath(unittest.TestCase):
   def test_builtin_string(self):
     self.assertEqual(execute("replace('foobar','oob','baz')"), 'fbazar')
     self.assertEqual(execute("replace('foobar', /[obr]/, '.')"), 'f...a.')
+    self.assertEqual(execute("replace('foobar', {'a': 'baz', /o+/: '.', 'f': 'bat'})"), 'bat.bbazr')
     self.assertEqual(execute("""escape('&lt;')"""), "&amp;lt;")
     self.assertEqual(execute("""escape('<"&>')"""), "&lt;&quot;&amp;&gt;")
     self.assertEqual(execute("""unescape('&lt;&quot;&amp;&gt;')"""), "<\"&>")


### PR DESCRIPTION
These changes to the string replace function are needed to enable company name normalization in metage's order 1 transformation configurations.